### PR TITLE
Fixes base profile for aws site

### DIFF
--- a/sites/staging-edge.devcluster.openshift.com/01_cluster-mods/kustomization.yaml
+++ b/sites/staging-edge.devcluster.openshift.com/01_cluster-mods/kustomization.yaml
@@ -1,2 +1,2 @@
 bases:
-- ../../../profiles/production.gcp/01_cluster-mods
+- ../../../profiles/production.aws/01_cluster-mods

--- a/sites/staging-edge.devcluster.openshift.com/02_cluster-addons/kustomization.yaml
+++ b/sites/staging-edge.devcluster.openshift.com/02_cluster-addons/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
-- ../../../profiles/production.gcp/02_cluster-addons
+- ../../../profiles/production.aws/02_cluster-addons
 
 patches:
 - 00_acm-registration/acm-name-config.patch.yaml

--- a/sites/staging-edge.devcluster.openshift.com/03_services/kustomization.yaml
+++ b/sites/staging-edge.devcluster.openshift.com/03_services/kustomization.yaml
@@ -1,3 +1,3 @@
 bases:
-- ../../../profiles/production.gcp/03_services
+- ../../../profiles/production.aws/03_services
 - subscription


### PR DESCRIPTION
staging-edge.devcluster.openshift.com is using the GCP profile instead of the AWS.